### PR TITLE
Remove sbt-conductr dependency

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,5 @@ resolvers ++= Seq(
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.2")
 
 // ConductR
-
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.1")
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.1.2")
 


### PR DESCRIPTION
Remove `sbt-conductr` dependency because `sbt-conductr-sandbox` already includes it.

For more infos see issue: typesafehub/sbt-conductr-sandbox#49.
